### PR TITLE
Updating matplotlib to let it run without X server

### DIFF
--- a/src/naarad/graphing/matplotlib_naarad.py
+++ b/src/naarad/graphing/matplotlib_naarad.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distribute
 import numpy
 import os
 import matplotlib as mpl
+mpl.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from mpl_toolkits.axes_grid1 import host_subplot


### PR DESCRIPTION
See this: http://stackoverflow.com/questions/13336823/matplotlib-python-error

I ran into this problem when trying to run it on a corp machine.
