### PR TITLE
Support GC Logs with extra timestamps

### DIFF
--- a/bin/PrintGCStats
+++ b/bin/PrintGCStats
@@ -755,7 +755,7 @@ function printInterval() {
 }
 
 $0 ~ ".*\\[GC[^ ]+ .*" {
-  sub(/GC[^ ]+/, "[GC", $0)
+  sub(/GC[^ ]+/, "GC", $0)
 }
 
 $0 ~ ".* age .*" {


### PR DESCRIPTION
Some gc logs have extra timestamps appended to GC loglines, such as below. This pull request adds support for these logs.

```
2014-04-03T18:06:56.265+0000: 170596.108: [GC2014-04-03T18:06:56.265+0000: 170596.108: [ParNew
Desired survivor size 429490176 bytes, new threshold 7 (max 7)
- age   1:   11542200 bytes,   11542200 total
- age   2:    6977520 bytes,   18519720 total
- age   3:    7344056 bytes,   25863776 total
- age   4:    4768352 bytes,   30632128 total
- age   5:    2791192 bytes,   33423320 total
- age   6:    2773336 bytes,   36196656 total
- age   7:    2426552 bytes,   38623208 total
: 2564634K->54029K(3355456K), 0.0201750 secs] 3977332K->1468436K(7549760K), 0.0206750 secs] [Times: user=0.26 sys=0.00, real=0.02 secs]
```
