### PR TITLE
change matplotlib requirement to >=1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyparsing>=2.0.1
-matplotlib==1.3.1
+matplotlib>=1.1.1
 numpy>=1.7.0
 argparse
 pytz>=2013.8


### PR DESCRIPTION
Looks like we don't need matplotlib 1.3.1. It works on my linux (1.2.1) and mac (1.1.1), so changing the requirement.txt to >=1.1.1
