### PR TITLE
Adding gitignore to src folder to ignore .pyc files.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled python files in source
+*.pyc


### PR DESCRIPTION
Getting annoyed about the compiled python files being in `git status`. This will also avoid any possibilities that somebody accidentally checks in `pyc` files.
