### PR TITLE
Fix bug in timestamp conversion for epoch

### DIFF
--- a/src/naarad/utils.py
+++ b/src/naarad/utils.py
@@ -663,7 +663,7 @@ def get_standardized_timestamp(timestamp, ts_format):
       logger.error('Unable to determine timestamp format for : %s', timestamp)
       return -1
     elif ts_format == 'epoch':
-      ts = timestamp * 1000
+      ts = int(timestamp) * 1000
     elif ts_format == 'epoch_ms':
       ts = timestamp
     elif ts_format in ('%H:%M:%S', '%H:%M:%S.%f'):


### PR DESCRIPTION
If the timestamp format is detected to be epoch,
we should multiply the numeric value of the
timestamp by 1000, to get milliseconds.

This fixes a bug in the code, where the
conversion was actually multiplying the
string 1000 times. This happened when
using the custom csv metric