### PR TITLE
Only check plot name if input specifies plots

### DIFF
--- a/bin/PrintGCStats
+++ b/bin/PrintGCStats
@@ -507,7 +507,7 @@ BEGIN {
       }
     } 
 
-    if (available_plot_count == 0) {
+    if (available_plot_count == 0 && requested_plot_count > 0) {
       print "PrintGCStats:  unrecognized plot name plot=" plot ".";
       print usage_msg;
       exit(1);


### PR DESCRIPTION
Bugfix to make it possible to run without plots, for example
bin/PrintGCStats -v cpus=4 -v interval=60  -v datestamps=1   /tmp/gc.log.0