### PR TITLE
Adding a Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,50 @@ dist/
 downloads/
 eggs/
 .eggs/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
 
 # Mac Files
 .DS_Store
 .AppleDouble
 .LSOverride
 
-# Temporary Files
+# Temporary Files from Editors
 *.swp
 *.swo
 \#*\#

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+
+# Mac Files
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Temporary Files
+*.swp
+*.swo
+\#*\#


### PR DESCRIPTION
Adding a `.gitignore` file that includes ignoring `virtualenv`, build files, compiled files, and temporary files by Vim or Emacs.