### PR TITLE
Add gc metric for allocation per second

### DIFF
--- a/bin/PrintGCStats
+++ b/bin/PrintGCStats
@@ -317,6 +317,7 @@ BEGIN {
   cmsCS_idx = ++i;	# CMS Concurrent Sweep
   cmsCR_idx = ++i;	# CMS Concurrent Reset
   MB_a_idx = ++i;	# MB allocated
+  MB_a_per_s_idx = ++i;	# MB allocated per second
   MB_p_idx = ++i;	# MB promoted
   MB_used0_idx = ++i;	# MB used in young gen
   MB_used1_idx = ++i;	# MB used in old gen
@@ -356,6 +357,9 @@ BEGIN {
 
   plot_cnt = -1;	# Used to identify plot lines if timestamps are not
   			# available.
+
+  # Previous timestamp for allocation
+  prev_alloc_timestamp = 0;
 
   # Init arrays.
   name_v[gen0c_idx]	= "gen0";
@@ -454,6 +458,7 @@ BEGIN {
   name_v[cmsCS_idx]	= "cmsCS";
   name_v[cmsCR_idx]	= "cmsCR";
   name_v[MB_a_idx]	= "alloc";
+  name_v[MB_a_per_s_idx]	= "allocPerSecond";
   name_v[MB_p_idx]	= "promo";
   name_v[MB_used0_idx]	= "used0";
   name_v[MB_used1_idx]	= "used1";
@@ -854,6 +859,22 @@ function parseHeapSizes(sizes, str) {
 function recordHeapKb(str) {
   if (parseHeapSizes(tmp_mb, str) < 0) return;
   recordStats(MB_a_idx, tmp_mb[0] - gen0_sizes[1]);
+  if(prev_alloc_timestamp > 0) {
+    if (datestamps == 1) {
+      curr_alloc_timestamp = getDateTimeStamp();
+    } else {
+      curr_alloc_timestamp = getTimeStamp();
+    }
+    recordStats(MB_a_per_s_idx, (tmp_mb[0] - gen0_sizes[1]) / ((curr_alloc_timestamp - prev_alloc_timestamp) / 1000));
+    prev_alloc_timestamp = curr_alloc_timestamp;
+  }
+  else {
+    if (datestamps == 1) {
+      prev_alloc_timestamp = getDateTimeStamp();
+    } else {
+      prev_alloc_timestamp = getTimeStamp();
+    }
+  }
   # Occupancy (the before gc value is used).
   recordStats(MB_usedh_idx, tmp_mb[0]);
   # Total heap committed size.
@@ -873,6 +894,23 @@ function recordGen0Kb(str, allow_3_sizes) {
   recordStats(MB_used0_idx, tmp_mb[0]);
   recordStats(MB_used0AfterGC_idx, tmp_mb[1]);
   recordStats(MB_a_idx, tmp_mb[0] - gen0_sizes[1]);
+  if(prev_alloc_timestamp > 0) {
+    if (datestamps == 1) {
+      curr_alloc_timestamp = getDateTimeStamp();
+    } else {
+      curr_alloc_timestamp = getTimeStamp();
+    }
+    recordStats(MB_a_per_s_idx, (tmp_mb[0] - gen0_sizes[1]) / ((curr_alloc_timestamp - prev_alloc_timestamp) / 1000));
+    prev_alloc_timestamp = curr_alloc_timestamp;
+  }
+  else {
+    if (datestamps == 1) {
+      prev_alloc_timestamp = getDateTimeStamp();
+    } else {
+      prev_alloc_timestamp = getTimeStamp();
+    }
+  }
+
   # Gen0 committed size.
   recordStats(MB_c0_idx, tmp_mb[2]);
 

--- a/src/naarad/metrics/gc_metric.py
+++ b/src/naarad/metrics/gc_metric.py
@@ -27,7 +27,7 @@ class GCMetric(Metric):
   """ Class for GC logs, deriving from class Metric """
   clock_format = '%Y-%m-%d %H:%M:%S'
   rate_types = ()
-  val_types = ('alloc', 'promo', 'used0', 'used1', 'used', 'commit0', 'commit1', 'commit', 'gen0', 'gen0t', 'gen0usr', 'gen0sys', 'gen0real',
+  val_types = ('alloc', 'allocPerSecond', 'promo', 'used0', 'used1', 'used', 'commit0', 'commit1', 'commit', 'gen0', 'gen0t', 'gen0usr', 'gen0sys', 'gen0real',
       'cmsIM', 'cmsRM', 'cmsRS', 'GCPause', 'cmsCM', 'cmsCP', 'cmsCS', 'cmsCR', 'safept', 'apptime', 'used0AfterGC', 'used1AfterGC', 'usedAfterGC',
       'gen1t', 'g1-pause-young', 'g1-pause-mixed', 'g1-pause-remark', 'g1-pause-cleanup', 'g1-pause-remark.ref-proc', 'g1-pause-young.parallel',
       'g1-pause-young.parallel.gcworkers', 'g1-pause-young.parallel.ext-root-scanning.avg', 'g1-pause-young.parallel.ext-root-scanning.max',
@@ -83,6 +83,7 @@ class GCMetric(Metric):
       'cmsCS' : 'CMS concurrent sweep phase',
       'cmsCR' : 'CMS concurrent reset phase',
       'alloc' : 'object allocation in MB (approximate***)',
+      'allocPerSecond' : 'object allocation in MB per second (approximate***)',
       'promo' : 'object promotion in MB (approximate***)',
       'used0' : 'young gen used memory size (before gc)',
       'used1' : 'old gen used memory size (before gc)',


### PR DESCRIPTION
For now, I just want feedback if this is something you also see as useful.
If you see it as useful, I will also add promotion per second.

The reason for having the alloction / promotion per second, is that when just using the "promotion" and "allocation" since last garbage collect, I get a constant number, for example 100MB of allocation, because the garbage collect kicks in after a number of bytes has been allocated. So sometimes there is 10 seconds between the garbage collect and sometimes there is 2 hours.

So I need the rate per second, to be able to see how "much" allocation is actually happening "per second".
