### PR TITLE
Bug gcprocess awk

### DIFF
--- a/bin/PrintGCStats
+++ b/bin/PrintGCStats
@@ -1,4 +1,4 @@
-#! /usr/bin/awk -f
+#! /usr/local/bin/gawk -f
 
 # Note:  /bin/nawk on Solaris 9 seems to have a bug; the RSTART and RLENGTH
 # vars are not set correctly during the last call to match() in

--- a/src/naarad/__init__.py
+++ b/src/naarad/__init__.py
@@ -385,6 +385,7 @@ class Naarad(object):
     crossplots = []
     report_args = {}
     graphing_library = None
+    ts_start,ts_end = None,None
 
     if config.has_section('GLOBAL'):
       ts_start, ts_end = naarad.utils.parse_global_section(config, 'GLOBAL')

--- a/src/naarad/__init__.py
+++ b/src/naarad/__init__.py
@@ -427,6 +427,10 @@ class Naarad(object):
             naarad.utils.parse_basic_metric_options(config, section)
           sar_metrics = naarad.utils.get_all_sar_objects(metrics, infile, hostname, output_directory, label, ts_start,
                                                          ts_end, None)
+          if ts_start is not None:
+            sar_metric.ts_start = ts_start
+          if ts_end is not None:
+            sar_metric.ts_end = ts_end
           metrics['metrics'].extend(sar_metrics)
         else:
           new_metric = naarad.utils.parse_metric_section(config, section, metric_classes, metrics['metrics'],

--- a/src/naarad/__init__.py
+++ b/src/naarad/__init__.py
@@ -430,6 +430,10 @@ class Naarad(object):
         else:
           new_metric = naarad.utils.parse_metric_section(config, section, metric_classes, metrics['metrics'],
                                                          aggregate_metric_classes, output_directory, resource_path)
+          if ts_start is not None:
+            new_metric.ts_start = ts_start
+          if ts_end is not None:
+            new_metric.ts_end = ts_end
           new_metric.bin_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(
             os.path.dirname(os.path.abspath(__file__)))),'bin'))
           metric_type = section.split('-')[0]


### PR DESCRIPTION
- In order to process gc log, "gc_metric.py" use awk to process the gc log. But the "bin/PrintGCStats" uses one "mktime" command which is no longer supported by awk. This will cause the gc log parsing failed. Switch from awk to gawk, and the issue got fixed.
- This pull request includes fix for bug 227. 
