### PR TITLE
Adding check for granularity being None

### DIFF
--- a/src/naarad/metrics/metric.py
+++ b/src/naarad/metrics/metric.py
@@ -190,7 +190,7 @@ class Metric(object):
     :param string granularity: aggregation granularity used for plots.
     :return: string aggregate_timestamp: timestamp used for metrics aggregation in all functions
     """
-    if granularity.lower() == 'none':
+    if granularity is None or granularity.lower() == 'none':
       return int(timestamp), 1
     elif granularity == 'hour':
       return (int(timestamp) / (3600 * 1000)) * 3600 * 1000, 3600


### PR DESCRIPTION
This fixes an issue with the newest pull request #329 in which configurations require `aggr_metrics` otherwise it'll fail. *This is critical to allow this option to be optional.*

This does not fix the issue when `aggr_metrics=none` and aggregation is not correct for QPS as below example would show QPS = 1 when should have two data points of 4 and 1. Nor does this fix plotting issues.

Example:

*data.csv*

```
1433409051000,30
1433409051200,10
1433409051300,30
1433409051400,16
1433409061000,30
```

*naarad.conf*

```
[Latency]
infile=data.csv
sep=,
columns=test
aggr_metrics=none

[GRAPH]
graphing_library=matplotlib
```