### PR TITLE
Fix bin path resolution

### DIFF
--- a/src/naarad/__init__.py
+++ b/src/naarad/__init__.py
@@ -467,8 +467,6 @@ class Naarad(object):
             new_metric.ts_start = ts_start
           if new_metric.ts_end is None and (new_metric.ts_start is None or ts_end > new_metric.ts_start):
             new_metric.ts_end = ts_end
-          new_metric.bin_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(
-              os.path.dirname(os.path.abspath(__file__)))), 'bin'))
           metric_type = section.split('-')[0]
           if metric_type in aggregate_metric_classes:
             metrics['aggregate_metrics'].append(new_metric)

--- a/src/naarad/metrics/gc_metric.py
+++ b/src/naarad/metrics/gc_metric.py
@@ -31,6 +31,8 @@ logger = logging.getLogger('naarad.metrics.GCMetric')
 
 class GCMetric(Metric):
   """ Class for GC logs, deriving from class Metric """
+
+  bin_path = os.path.dirname(sys.argv[0])
   clock_format = '%Y-%m-%d %H:%M:%S'
   rate_types = ()
   val_types = ('alloc', 'promo', 'used0', 'used1', 'used', 'commit0', 'commit1', 'commit', 'gen0', 'gen0t', 'gen0usr', 'gen0sys', 'gen0real',

--- a/src/naarad/utils.py
+++ b/src/naarad/utils.py
@@ -949,7 +949,6 @@ def initialize_metric(section, infile_list, hostname, aggr_metrics, output_direc
   :param: other_options: kwargs
   :return: metric object
   """
-  bin_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'bin'))
   metric = None
   metric_type = section.split('-')[0]
   if metric_type in metric_classes:
@@ -962,7 +961,6 @@ def initialize_metric(section, infile_list, hostname, aggr_metrics, output_direc
   else:
     metric = Metric(section, infile_list, hostname, aggr_metrics, output_directory, resource_path, label, ts_start, ts_end, rule_strings,
                     important_sub_metrics, anomaly_detection_metrics, **other_options)
-  metric.bin_path = bin_path
   return metric
 
 
@@ -984,10 +982,8 @@ def initialize_aggregate_metric(section, aggr_hosts, aggr_metrics, metrics, outd
   :param: other_options: kwargs
   :return: metric object
   """
-  bin_path = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'bin'))
   metric = None
   metric_type = section.split('-')[0]
   metric = aggregate_metric_classes[metric_type](section, aggr_hosts, aggr_metrics, metrics, outdir_default, resource_path, label, ts_start, ts_end,
                                                  rule_strings, important_sub_metrics, anomaly_detection_metrics, **other_options)
-  metric.bin_path = bin_path
   return metric


### PR DESCRIPTION
Determine the bin path based on the location of the naarad script instead of
the location of the utils module, which allows naarad to function correctly
when installed in a virtualenv environment.

Fixes #345.

Tested in a virtualenv sandbox after installing naarad with pip, and also from within the git repo itself.